### PR TITLE
🤖 Serialize the constituent errors of an AggregateError

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - `[@holz/json-backend]` Entries now include `log.owner`.
 - `[@holz/json-backend]` New optional `signal` option. Pass an `AbortSignal` to close the stream on shutdown, flushing queued writes.
 
+### Fixed
+
+- `[@holz/json-backend]` Special-case [AggregateError](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/AggregateError) to include the non-enumerable `errors[]` field.
+
 ### Changed
 
 - `[@holz/core]` The special `error` type in log context was widened from `Error` to `unknown` matching the type signature of try/catch and `.catch` handlers.

--- a/packages/holz-json-backend/src/__tests__/json-backend.test.ts
+++ b/packages/holz-json-backend/src/__tests__/json-backend.test.ts
@@ -131,6 +131,69 @@ describe('JSON backend', () => {
     );
   });
 
+  it('serializes a cause that is not an error', async () => {
+    const { stream, signal, getOutput } = createStream();
+    const backend = createJsonBackend({ stream, signal });
+    const logger = createLogger(backend);
+
+    logger.error('content', {
+      error: new Error('Testing NDJSON errors', {
+        cause: { code: 'EACCES', retryable: false },
+      }),
+    });
+
+    expect(await getOutput()).toContain(
+      '"error":{"name":"Error","message":"Testing NDJSON errors","cause":{"code":"EACCES","retryable":false}}',
+    );
+  });
+
+  it('serializes a primitive cause', async () => {
+    const { stream, signal, getOutput } = createStream();
+    const backend = createJsonBackend({ stream, signal });
+    const logger = createLogger(backend);
+
+    logger.error('content', {
+      error: new Error('Testing NDJSON errors', { cause: 'plain string' }),
+    });
+
+    expect(await getOutput()).toContain(
+      '"error":{"name":"Error","message":"Testing NDJSON errors","cause":"plain string"}',
+    );
+  });
+
+  it('unpacks the constituent errors of an AggregateError', async () => {
+    const { stream, signal, getOutput } = createStream();
+    const backend = createJsonBackend({ stream, signal });
+    const logger = createLogger(backend);
+
+    logger.error('content', {
+      error: new AggregateError(
+        [new Error('First failure'), new TypeError('Second failure')],
+        'Everything failed',
+      ),
+    });
+
+    expect(await getOutput()).toContain(
+      '"error":{"name":"AggregateError","message":"Everything failed","errors":[{"name":"Error","message":"First failure"},{"name":"TypeError","message":"Second failure"}]}',
+    );
+  });
+
+  it('detects a cause alongside an AggregateError', async () => {
+    const { stream, signal, getOutput } = createStream();
+    const backend = createJsonBackend({ stream, signal });
+    const logger = createLogger(backend);
+
+    logger.error('content', {
+      error: new AggregateError([new Error('Inner')], 'Outer', {
+        cause: new Error('Root cause'),
+      }),
+    });
+
+    expect(await getOutput()).toContain(
+      '"error":{"name":"AggregateError","message":"Outer","cause":{"name":"Error","message":"Root cause"},"errors":[{"name":"Error","message":"Inner"}]}',
+    );
+  });
+
   it('includes any enumerable properties on the object', async () => {
     class CustomError extends Error {
       name = 'CustomError';

--- a/packages/holz-json-backend/src/json-backend.ts
+++ b/packages/holz-json-backend/src/json-backend.ts
@@ -80,6 +80,11 @@ const errorSerializer = (_key: string, value: unknown) => {
       name: value.name,
       message: value.message,
       cause: value.cause,
+      // `AggregateError` collects its constituent failures in a
+      // non-enumerable `errors` array that the spread above misses. Pull it
+      // explicitly so those underlying errors survive serialization; the
+      // replacer recurses into each one.
+      ...(value instanceof AggregateError && { errors: value.errors }),
     };
   }
 


### PR DESCRIPTION
> [!NOTE]
> I'm returning to this project. I continue to use AI in my projects, although it's more visible since agents improved.
>
> More details: d0f94e53aca3c041b5310fecaba7ae3a38f7ec0e

## TL;DR:

`@holz/json-backend` silently dropped the constituent errors of an `AggregateError`. This fixes the serializer to include them and adds test coverage for `AggregateError` and non-error `cause` values.

## Details

The error serializer flattened errors via a spread (`...value`) plus an explicit pull of `name`/`message`/`cause`. But `AggregateError.errors` is a **non-enumerable own property** — the spread skipped it and nothing pulled it back, so the very errors an `AggregateError` exists to carry were lost.

The fix pulls `errors` explicitly when the value is an `AggregateError`; the existing replacer then recurses into each element, serializing nested errors like any other.

New tests cover:
- `AggregateError` (with and without its own `cause`)
- a `cause` that is not an `Error` itself (plain object and primitive)

## Pros

- Fixes a real data-loss bug — aggregated failures now survive serialization.
- Pure addition to existing behavior; no change to how single errors serialize.
- Tightens coverage around error/`cause` edge cases.

## Cons

- Slightly more output for `AggregateError` logs (intended).
- Special-cases one error subtype in the serializer.

## Followup work

- Consider whether stack traces should be opt-in for serialized errors (currently always omitted).
