### PR TITLE
🤖 Revert the special error type widening

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Changed
 
-- `[@holz/core]` The special `error` type in log context was widened from `Error` to `unknown` matching the type signature of try/catch and `.catch` handlers.
 - `[@holz/json-backend]` The platform-specific `\r\n` was dropped for better portability. All systems write `\n` as the newline character.
 - `[@holz/json-backend]` Expects a WHATWG [WritableStream](https://developer.mozilla.org/en-US/docs/Web/API/WritableStream) instead of a Node Streams interface. Improves portability, particularly for browser environments.
 

--- a/packages/holz-core/src/types.ts
+++ b/packages/holz-core/src/types.ts
@@ -85,7 +85,7 @@ export interface CustomContext {
    * Error instance associated with the log message. This supports error
    * tracking and shows prominently in visual backends like TTY output.
    */
-  error: unknown;
+  error: Error;
 }
 
 /**


### PR DESCRIPTION
## TL;DR

Reverts `@holz/core`'s special `error` log-context type from `unknown` back to `Error`, and drops the now-obsolete CHANGELOG entry.

## Why

Widening `error` to `unknown` (to mirror the type signature of `try/catch` and `.catch` handlers) loses the stack trace at the most critical point and pushes narrowing into every downstream backend, complicating the pipeline.

Apps and libraries that log errors are responsible for ensuring they hold a real `Error` before logging. A coercion utility like `toError(...)`, wrapping non-error throws in a custom type with `cause: original`, is the right pattern — but it's too opinionated to generalize into the library. Keeping the type as `Error` encourages that discipline organically through the API.

## Pros

- Stack traces are preserved at the log call site.
- Backends no longer need to narrow `unknown` before featuring errors.
- The API nudges callers toward proper error coercion.

## Cons

- Callers logging straight out of a `catch` must coerce to `Error` themselves (the recast this widening was meant to avoid). This is intentional — the responsibility belongs with the caller.

## Recommended follow-up

- Consider documenting a recommended `toError(...)`-style coercion pattern in the README so users have a clear path, without the library prescribing a specific implementation.