### PR TITLE
🤖 Auto-publish rc-tagged canary releases on merge to main

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,71 @@
+name: Release
+
+on:
+  push:
+    branches: [main]
+    # Skip publishing when a merge only touches Markdown. Mixed pushes (a
+    # .md plus real code) still run; this only fires when *every* changed
+    # file is Markdown.
+    paths-ignore:
+      - '**/*.md'
+
+# Never let two publishes race; a queued run waits rather than cancels so we
+# don't abandon a publish midway.
+concurrency:
+  group: release
+  cancel-in-progress: false
+
+# Minimal by default; the publish job opts into id-token below.
+permissions:
+  contents: read
+
+jobs:
+  publish-rc:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      # Required for npm OIDC trusted publishing (no NPM_TOKEN).
+      id-token: write
+    env:
+      # Force ANSI color in tools that gate on TTY detection.
+      FORCE_COLOR: '3'
+      CLICOLOR_FORCE: '1'
+    # Run every shell step inside the flake's devShell so CI stays in
+    # sync with local dev (single source of truth in flake.nix).
+    defaults:
+      run:
+        shell: nix develop --command bash -eo pipefail {0}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          # Lerna derives canary versions from the latest release tag, so it
+          # needs full history and tags, not a shallow clone.
+          fetch-depth: 0
+      - uses: DeterminateSystems/nix-installer-action@v22
+      - uses: DeterminateSystems/magic-nix-cache-action@v14
+        with:
+          use-flakehub: false
+      # No-op that absorbs the first `nix develop` evaluation so its
+      # cost shows up here instead of inflating the next real step.
+      - name: Warm devShell
+        run: 'true'
+      - name: Restore pnpm store
+        uses: actions/cache@v5
+        with:
+          path: ~/.local/share/pnpm/store
+          key: ${{ runner.os }}-pnpm-${{ hashFiles('**/pnpm-lock.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-pnpm-
+      - name: Restore turbo cache
+        uses: actions/cache@v5
+        with:
+          path: .turbo
+          key: ${{ runner.os }}-turbo-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-turbo-
+      - run: pnpm install --frozen-lockfile
+      # Gate the publish on a clean tree. Direct pushes to main skip PR CI,
+      # so re-run checks here; turbo's cache makes this a near no-op when CI
+      # already passed for this commit.
+      - run: pnpm check
+      - run: pnpm release:candidate

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "test": "pnpm check",
     "test:coverage": "pnpm -r run test:unit -- --coverage --no-watch",
     "lint": "eslint packages/*/src --ext ts,tsx --color --cache --cache-location node_modules/.cache/eslint/",
-    "fmt-check": "treefmt --ci"
+    "fmt-check": "treefmt --ci",
+    "release:candidate": "lerna publish --canary --preid rc --dist-tag rc --force-publish --yes"
   },
   "prettier": {
     "singleQuote": true


### PR DESCRIPTION
## TL;DR

Adds a `release.yml` workflow that publishes every `@holz/*` package under the npm **`rc`** dist-tag on every merge to `main`, using lerna canary releases and npm **OIDC trusted publishing** (no `NPM_TOKEN`). Consumers opt in with `npm i @holz/<pkg>@rc`; the `latest` tag is never touched.

## What it does

- **`release:candidate` script** → `lerna publish --canary --preid rc --dist-tag rc --force-publish --yes`. Produces versions like `0.8.3-rc.412+<sha>` where the numeric segment is the git commit count (monotonic → collision-free across merges), published under dist-tag `rc`.
- **`.github/workflows/release.yml`** → on push to `main`, runs inside the flake devShell (Node 24 / npm 11.12, both above the OIDC floor of 22.14 / 11.5.1), `id-token: write`, `pnpm install` → `pnpm check` → `pnpm release:candidate`.
- **`paths-ignore: ['**/*.md']`** → a merge that only touches Markdown skips publishing entirely. Mixed pushes still run.

## Design notes

- **Auth is OIDC, not a token.** Lerna v9 routes the publish through the npm CLI, which performs the OIDC handshake. Requires a one-time per-package trusted-publisher config on npmjs.com (see Followups) — without it the publish step fails to authenticate.
- **`--force-publish`** republishes all 9 packages every run rather than only changed ones, so a package-free merge can't fail the job with "no changed packages to publish." Trade-off: unchanged packages get a fresh rc each time (cheap, off `latest`).
- **`pnpm check` re-runs in the publish job** because direct pushes to `main` skip PR CI; turbo's cache makes it near-free when CI already passed for the commit.

## Pros

- Every merge yields an installable `@rc` build with zero manual steps.
- No long-lived npm credentials in the repo (OIDC).
- Canary versioning is stateless and collision-proof; `latest` consumers are unaffected.

## Cons

- Requires per-package trusted-publisher setup on npmjs.com before the first publish authenticates (npm has no org/scope-wide config).
- `--force-publish` means unchanged packages still get new rc versions on every merge.
- `**/*.md` also matches package READMEs (which npm publishes), so a README-only change won't refresh the npmjs.com page until the next code release.

## Recommended followups

- Configure trusted publishers for all 9 packages (one-time), e.g. via the bulk `npm trust github` CLI (npm ≥ 11.10):
  ```bash
  for pkg in ansi-terminal-backend console-backend core env-filter \
             json-backend log-collector logger pattern-filter stream-backend; do
    npm trust github "@holz/$pkg" --file release.yml --repo PsychoLlama/holz --allow-publish --yes
    sleep 2
  done
  ```
- Consider a matching `release:stable` path later if/when you want promoted releases driven from CI too.