### PR TITLE
🤖 Add AGENTS.md with project conventions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,15 @@
+## Stack
+
+- pnpm (workspace)
+- Turbo
+- Nix (flakes)
+
+## Structure
+
+- `packages/<name>` is symmetric to `pkg.name`, e.g. `@holz/json-backend` is `holz-json-backend`.
+- `packages/holz-core` contains core logic other packages (plugins) extend.
+
+## Rules
+
+- No runtime dependencies except packages in this workspace. `node:*` imports are the exception.
+- `pnpm check` must pass before committing.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md


### PR DESCRIPTION
## TL;DR

Adds an `AGENTS.md` documenting the project's stack, package naming convention, and contribution rules. `CLAUDE.md` re-exports it so both toolchains read the same source of truth.

## Changes

- **`AGENTS.md`** — stack (pnpm/Turbo/Nix), the `packages/<name>` ↔ `pkg.name` symmetry, and the no-runtime-deps / `pnpm check` rules.
- **`CLAUDE.md`** — single-line `@AGENTS.md` import to avoid duplication.

## Pros

- One canonical place for agent-facing conventions.
- No duplication between Claude and other tooling.

## Cons

- Docs can drift from reality if not maintained.

## Recommended followup

- Cross-link from the repo README once conventions stabilize.