### PR TITLE
🤖 Fix broken type bundling under vite-plugin-dts v5

### DIFF
--- a/packages/holz-ansi-terminal-backend/package.json
+++ b/packages/holz-ansi-terminal-backend/package.json
@@ -39,6 +39,7 @@
   },
   "devDependencies": {
     "@holz/core": "workspace:^",
+    "@microsoft/api-extractor": "^7.58.8",
     "@types/node": "^24.0.0",
     "@vitest/coverage-v8": "^4.0.0",
     "typescript": "^6.0.0",

--- a/packages/holz-ansi-terminal-backend/vite.config.ts
+++ b/packages/holz-ansi-terminal-backend/vite.config.ts
@@ -10,7 +10,13 @@ export default async () => {
   const builtins = builtinModules.map((name) => `node:${name}`);
 
   return defineConfig({
-    plugins: [dts({ rollupTypes: true, pathsToAliases: false })],
+    plugins: [
+      dts({
+        bundleTypes: true,
+        pathsToAliases: false,
+        compilerOptions: { paths: {}, rootDir: 'src' },
+      }),
+    ],
     build: {
       lib: {
         entry: './src/index.ts',

--- a/packages/holz-console-backend/package.json
+++ b/packages/holz-console-backend/package.json
@@ -40,6 +40,7 @@
   },
   "devDependencies": {
     "@holz/core": "workspace:^",
+    "@microsoft/api-extractor": "^7.58.8",
     "@types/node": "^24.0.0",
     "@vitest/coverage-v8": "^4.0.0",
     "typescript": "^6.0.0",

--- a/packages/holz-console-backend/vite.config.ts
+++ b/packages/holz-console-backend/vite.config.ts
@@ -3,7 +3,13 @@ import dts from 'vite-plugin-dts';
 
 export default async () => {
   return defineConfig({
-    plugins: [dts({ rollupTypes: true, pathsToAliases: false })],
+    plugins: [
+      dts({
+        bundleTypes: true,
+        pathsToAliases: false,
+        compilerOptions: { paths: {}, rootDir: 'src' },
+      }),
+    ],
     build: {
       lib: {
         entry: './src/index.ts',

--- a/packages/holz-core/package.json
+++ b/packages/holz-core/package.json
@@ -35,6 +35,7 @@
     "test:types": "tsc"
   },
   "devDependencies": {
+    "@microsoft/api-extractor": "^7.58.8",
     "@vitest/coverage-v8": "^4.0.0",
     "typescript": "^6.0.0",
     "vite": "^8.0.0",

--- a/packages/holz-core/vite.config.ts
+++ b/packages/holz-core/vite.config.ts
@@ -3,7 +3,13 @@ import dts from 'vite-plugin-dts';
 
 export default async () => {
   return defineConfig({
-    plugins: [dts({ rollupTypes: true, pathsToAliases: false })],
+    plugins: [
+      dts({
+        bundleTypes: true,
+        pathsToAliases: false,
+        compilerOptions: { paths: {}, rootDir: 'src' },
+      }),
+    ],
     build: {
       lib: {
         entry: './src/index.ts',

--- a/packages/holz-env-filter/package.json
+++ b/packages/holz-env-filter/package.json
@@ -44,6 +44,7 @@
   },
   "devDependencies": {
     "@holz/core": "workspace:^",
+    "@microsoft/api-extractor": "^7.58.8",
     "@types/node": "^24.0.0",
     "@vitest/coverage-v8": "^4.0.0",
     "typescript": "^6.0.0",

--- a/packages/holz-env-filter/vite.config.ts
+++ b/packages/holz-env-filter/vite.config.ts
@@ -7,7 +7,13 @@ export default async () => {
   const externals = Object.keys(pkg.dependencies ?? {});
 
   return defineConfig({
-    plugins: [dts({ rollupTypes: true, pathsToAliases: false })],
+    plugins: [
+      dts({
+        bundleTypes: true,
+        pathsToAliases: false,
+        compilerOptions: { paths: {}, rootDir: 'src' },
+      }),
+    ],
     build: {
       lib: {
         entry: './src/index.ts',

--- a/packages/holz-json-backend/package.json
+++ b/packages/holz-json-backend/package.json
@@ -37,6 +37,7 @@
   },
   "devDependencies": {
     "@holz/core": "workspace:^",
+    "@microsoft/api-extractor": "^7.58.8",
     "@types/node": "^24.0.0",
     "@vitest/coverage-v8": "^4.0.0",
     "typescript": "^6.0.0",

--- a/packages/holz-json-backend/vite.config.ts
+++ b/packages/holz-json-backend/vite.config.ts
@@ -6,7 +6,13 @@ export default async () => {
   const builtins = builtinModules.map((name) => `node:${name}`);
 
   return defineConfig({
-    plugins: [dts({ rollupTypes: true, pathsToAliases: false })],
+    plugins: [
+      dts({
+        bundleTypes: true,
+        pathsToAliases: false,
+        compilerOptions: { paths: {}, rootDir: 'src' },
+      }),
+    ],
     build: {
       lib: {
         entry: './src/index.ts',

--- a/packages/holz-log-collector/package.json
+++ b/packages/holz-log-collector/package.json
@@ -40,6 +40,7 @@
   },
   "devDependencies": {
     "@holz/core": "workspace:^",
+    "@microsoft/api-extractor": "^7.58.8",
     "@types/node": "^24.0.0",
     "@vitest/coverage-v8": "^4.0.0",
     "typescript": "^6.0.0",

--- a/packages/holz-log-collector/vite.config.ts
+++ b/packages/holz-log-collector/vite.config.ts
@@ -6,7 +6,13 @@ export default async () => {
   const builtins = builtinModules.map((name) => `node:${name}`);
 
   return defineConfig({
-    plugins: [dts({ rollupTypes: true, pathsToAliases: false })],
+    plugins: [
+      dts({
+        bundleTypes: true,
+        pathsToAliases: false,
+        compilerOptions: { paths: {}, rootDir: 'src' },
+      }),
+    ],
     build: {
       lib: {
         entry: './src/index.ts',

--- a/packages/holz-logger/package.json
+++ b/packages/holz-logger/package.json
@@ -53,6 +53,7 @@
     "@holz/stream-backend": "workspace:^"
   },
   "devDependencies": {
+    "@microsoft/api-extractor": "^7.58.8",
     "@types/node": "^24.0.0",
     "@vitest/coverage-v8": "^4.0.0",
     "typescript": "^6.0.0",

--- a/packages/holz-logger/vite.config.ts
+++ b/packages/holz-logger/vite.config.ts
@@ -9,7 +9,13 @@ export default async () => {
   const builtins = builtinModules.map((name) => `node:${name}`);
 
   return defineConfig({
-    plugins: [dts({ rollupTypes: true, pathsToAliases: false })],
+    plugins: [
+      dts({
+        bundleTypes: true,
+        pathsToAliases: false,
+        compilerOptions: { paths: {}, rootDir: 'src' },
+      }),
+    ],
     build: {
       lib: {
         entry: {

--- a/packages/holz-pattern-filter/package.json
+++ b/packages/holz-pattern-filter/package.json
@@ -41,6 +41,7 @@
   },
   "devDependencies": {
     "@holz/core": "workspace:^",
+    "@microsoft/api-extractor": "^7.58.8",
     "@vitest/coverage-v8": "^4.0.0",
     "typescript": "^6.0.0",
     "vite": "^8.0.0",

--- a/packages/holz-pattern-filter/vite.config.ts
+++ b/packages/holz-pattern-filter/vite.config.ts
@@ -3,7 +3,13 @@ import dts from 'vite-plugin-dts';
 
 export default async () => {
   return defineConfig({
-    plugins: [dts({ rollupTypes: true, pathsToAliases: false })],
+    plugins: [
+      dts({
+        bundleTypes: true,
+        pathsToAliases: false,
+        compilerOptions: { paths: {}, rootDir: 'src' },
+      }),
+    ],
     build: {
       lib: {
         entry: './src/index.ts',

--- a/packages/holz-stream-backend/package.json
+++ b/packages/holz-stream-backend/package.json
@@ -40,6 +40,7 @@
   },
   "devDependencies": {
     "@holz/core": "workspace:^",
+    "@microsoft/api-extractor": "^7.58.8",
     "@types/node": "^24.0.0",
     "@vitest/coverage-v8": "^4.0.0",
     "typescript": "^6.0.0",

--- a/packages/holz-stream-backend/vite.config.ts
+++ b/packages/holz-stream-backend/vite.config.ts
@@ -10,7 +10,13 @@ export default async () => {
   const builtins = builtinModules.map((name) => `node:${name}`);
 
   return defineConfig({
-    plugins: [dts({ rollupTypes: true, pathsToAliases: false })],
+    plugins: [
+      dts({
+        bundleTypes: true,
+        pathsToAliases: false,
+        compilerOptions: { paths: {}, rootDir: 'src' },
+      }),
+    ],
     build: {
       lib: {
         entry: './src/index.ts',

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -47,6 +47,9 @@ importers:
       '@holz/core':
         specifier: workspace:^
         version: link:../holz-core
+      '@microsoft/api-extractor':
+        specifier: ^7.58.8
+        version: 7.58.8(@types/node@24.13.2)
       '@types/node':
         specifier: ^24.0.0
         version: 24.13.2
@@ -61,7 +64,7 @@ importers:
         version: 8.0.16(@types/node@24.13.2)(esbuild@0.27.7)(yaml@2.9.0)
       vite-plugin-dts:
         specifier: ^5.0.0
-        version: 5.0.2(esbuild@0.27.7)(rolldown@1.0.3)(rollup@4.61.1)(typescript@6.0.3)(vite@8.0.16(@types/node@24.13.2)(esbuild@0.27.7)(yaml@2.9.0))
+        version: 5.0.2(@microsoft/api-extractor@7.58.8(@types/node@24.13.2))(esbuild@0.27.7)(rolldown@1.0.3)(rollup@4.61.1)(typescript@6.0.3)(vite@8.0.16(@types/node@24.13.2)(esbuild@0.27.7)(yaml@2.9.0))
       vite-tsconfig-paths:
         specifier: ^6.0.0
         version: 6.1.1(typescript@6.0.3)(vite@8.0.16(@types/node@24.13.2)(esbuild@0.27.7)(yaml@2.9.0))
@@ -74,6 +77,9 @@ importers:
       '@holz/core':
         specifier: workspace:^
         version: link:../holz-core
+      '@microsoft/api-extractor':
+        specifier: ^7.58.8
+        version: 7.58.8(@types/node@24.13.2)
       '@types/node':
         specifier: ^24.0.0
         version: 24.13.2
@@ -88,7 +94,7 @@ importers:
         version: 8.0.16(@types/node@24.13.2)(esbuild@0.27.7)(yaml@2.9.0)
       vite-plugin-dts:
         specifier: ^5.0.0
-        version: 5.0.2(esbuild@0.27.7)(rolldown@1.0.3)(rollup@4.61.1)(typescript@6.0.3)(vite@8.0.16(@types/node@24.13.2)(esbuild@0.27.7)(yaml@2.9.0))
+        version: 5.0.2(@microsoft/api-extractor@7.58.8(@types/node@24.13.2))(esbuild@0.27.7)(rolldown@1.0.3)(rollup@4.61.1)(typescript@6.0.3)(vite@8.0.16(@types/node@24.13.2)(esbuild@0.27.7)(yaml@2.9.0))
       vite-tsconfig-paths:
         specifier: ^6.0.0
         version: 6.1.1(typescript@6.0.3)(vite@8.0.16(@types/node@24.13.2)(esbuild@0.27.7)(yaml@2.9.0))
@@ -98,6 +104,9 @@ importers:
 
   packages/holz-core:
     devDependencies:
+      '@microsoft/api-extractor':
+        specifier: ^7.58.8
+        version: 7.58.8(@types/node@24.13.2)
       '@vitest/coverage-v8':
         specifier: ^4.0.0
         version: 4.1.8(vitest@4.1.8)
@@ -109,7 +118,7 @@ importers:
         version: 8.0.16(@types/node@24.13.2)(esbuild@0.27.7)(yaml@2.9.0)
       vite-plugin-dts:
         specifier: ^5.0.0
-        version: 5.0.2(esbuild@0.27.7)(rolldown@1.0.3)(rollup@4.61.1)(typescript@6.0.3)(vite@8.0.16(@types/node@24.13.2)(esbuild@0.27.7)(yaml@2.9.0))
+        version: 5.0.2(@microsoft/api-extractor@7.58.8(@types/node@24.13.2))(esbuild@0.27.7)(rolldown@1.0.3)(rollup@4.61.1)(typescript@6.0.3)(vite@8.0.16(@types/node@24.13.2)(esbuild@0.27.7)(yaml@2.9.0))
       vite-tsconfig-paths:
         specifier: ^6.0.0
         version: 6.1.1(typescript@6.0.3)(vite@8.0.16(@types/node@24.13.2)(esbuild@0.27.7)(yaml@2.9.0))
@@ -126,6 +135,9 @@ importers:
       '@holz/core':
         specifier: workspace:^
         version: link:../holz-core
+      '@microsoft/api-extractor':
+        specifier: ^7.58.8
+        version: 7.58.8(@types/node@24.13.2)
       '@types/node':
         specifier: ^24.0.0
         version: 24.13.2
@@ -140,7 +152,7 @@ importers:
         version: 8.0.16(@types/node@24.13.2)(esbuild@0.27.7)(yaml@2.9.0)
       vite-plugin-dts:
         specifier: ^5.0.0
-        version: 5.0.2(esbuild@0.27.7)(rolldown@1.0.3)(rollup@4.61.1)(typescript@6.0.3)(vite@8.0.16(@types/node@24.13.2)(esbuild@0.27.7)(yaml@2.9.0))
+        version: 5.0.2(@microsoft/api-extractor@7.58.8(@types/node@24.13.2))(esbuild@0.27.7)(rolldown@1.0.3)(rollup@4.61.1)(typescript@6.0.3)(vite@8.0.16(@types/node@24.13.2)(esbuild@0.27.7)(yaml@2.9.0))
       vite-tsconfig-paths:
         specifier: ^6.0.0
         version: 6.1.1(typescript@6.0.3)(vite@8.0.16(@types/node@24.13.2)(esbuild@0.27.7)(yaml@2.9.0))
@@ -153,6 +165,9 @@ importers:
       '@holz/core':
         specifier: workspace:^
         version: link:../holz-core
+      '@microsoft/api-extractor':
+        specifier: ^7.58.8
+        version: 7.58.8(@types/node@24.13.2)
       '@types/node':
         specifier: ^24.0.0
         version: 24.13.2
@@ -167,7 +182,7 @@ importers:
         version: 8.0.16(@types/node@24.13.2)(esbuild@0.27.7)(yaml@2.9.0)
       vite-plugin-dts:
         specifier: ^5.0.0
-        version: 5.0.2(esbuild@0.27.7)(rolldown@1.0.3)(rollup@4.61.1)(typescript@6.0.3)(vite@8.0.16(@types/node@24.13.2)(esbuild@0.27.7)(yaml@2.9.0))
+        version: 5.0.2(@microsoft/api-extractor@7.58.8(@types/node@24.13.2))(esbuild@0.27.7)(rolldown@1.0.3)(rollup@4.61.1)(typescript@6.0.3)(vite@8.0.16(@types/node@24.13.2)(esbuild@0.27.7)(yaml@2.9.0))
       vite-tsconfig-paths:
         specifier: ^6.0.0
         version: 6.1.1(typescript@6.0.3)(vite@8.0.16(@types/node@24.13.2)(esbuild@0.27.7)(yaml@2.9.0))
@@ -180,6 +195,9 @@ importers:
       '@holz/core':
         specifier: workspace:^
         version: link:../holz-core
+      '@microsoft/api-extractor':
+        specifier: ^7.58.8
+        version: 7.58.8(@types/node@24.13.2)
       '@types/node':
         specifier: ^24.0.0
         version: 24.13.2
@@ -194,7 +212,7 @@ importers:
         version: 8.0.16(@types/node@24.13.2)(esbuild@0.27.7)(yaml@2.9.0)
       vite-plugin-dts:
         specifier: ^5.0.0
-        version: 5.0.2(esbuild@0.27.7)(rolldown@1.0.3)(rollup@4.61.1)(typescript@6.0.3)(vite@8.0.16(@types/node@24.13.2)(esbuild@0.27.7)(yaml@2.9.0))
+        version: 5.0.2(@microsoft/api-extractor@7.58.8(@types/node@24.13.2))(esbuild@0.27.7)(rolldown@1.0.3)(rollup@4.61.1)(typescript@6.0.3)(vite@8.0.16(@types/node@24.13.2)(esbuild@0.27.7)(yaml@2.9.0))
       vite-tsconfig-paths:
         specifier: ^6.0.0
         version: 6.1.1(typescript@6.0.3)(vite@8.0.16(@types/node@24.13.2)(esbuild@0.27.7)(yaml@2.9.0))
@@ -223,6 +241,9 @@ importers:
         specifier: workspace:^
         version: link:../holz-stream-backend
     devDependencies:
+      '@microsoft/api-extractor':
+        specifier: ^7.58.8
+        version: 7.58.8(@types/node@24.13.2)
       '@types/node':
         specifier: ^24.0.0
         version: 24.13.2
@@ -237,7 +258,7 @@ importers:
         version: 8.0.16(@types/node@24.13.2)(esbuild@0.27.7)(yaml@2.9.0)
       vite-plugin-dts:
         specifier: ^5.0.0
-        version: 5.0.2(esbuild@0.27.7)(rolldown@1.0.3)(rollup@4.61.1)(typescript@6.0.3)(vite@8.0.16(@types/node@24.13.2)(esbuild@0.27.7)(yaml@2.9.0))
+        version: 5.0.2(@microsoft/api-extractor@7.58.8(@types/node@24.13.2))(esbuild@0.27.7)(rolldown@1.0.3)(rollup@4.61.1)(typescript@6.0.3)(vite@8.0.16(@types/node@24.13.2)(esbuild@0.27.7)(yaml@2.9.0))
       vite-tsconfig-paths:
         specifier: ^6.0.0
         version: 6.1.1(typescript@6.0.3)(vite@8.0.16(@types/node@24.13.2)(esbuild@0.27.7)(yaml@2.9.0))
@@ -250,6 +271,9 @@ importers:
       '@holz/core':
         specifier: workspace:^
         version: link:../holz-core
+      '@microsoft/api-extractor':
+        specifier: ^7.58.8
+        version: 7.58.8(@types/node@24.13.2)
       '@vitest/coverage-v8':
         specifier: ^4.0.0
         version: 4.1.8(vitest@4.1.8)
@@ -261,7 +285,7 @@ importers:
         version: 8.0.16(@types/node@24.13.2)(esbuild@0.27.7)(yaml@2.9.0)
       vite-plugin-dts:
         specifier: ^5.0.0
-        version: 5.0.2(esbuild@0.27.7)(rolldown@1.0.3)(rollup@4.61.1)(typescript@6.0.3)(vite@8.0.16(@types/node@24.13.2)(esbuild@0.27.7)(yaml@2.9.0))
+        version: 5.0.2(@microsoft/api-extractor@7.58.8(@types/node@24.13.2))(esbuild@0.27.7)(rolldown@1.0.3)(rollup@4.61.1)(typescript@6.0.3)(vite@8.0.16(@types/node@24.13.2)(esbuild@0.27.7)(yaml@2.9.0))
       vite-tsconfig-paths:
         specifier: ^6.0.0
         version: 6.1.1(typescript@6.0.3)(vite@8.0.16(@types/node@24.13.2)(esbuild@0.27.7)(yaml@2.9.0))
@@ -274,6 +298,9 @@ importers:
       '@holz/core':
         specifier: workspace:^
         version: link:../holz-core
+      '@microsoft/api-extractor':
+        specifier: ^7.58.8
+        version: 7.58.8(@types/node@24.13.2)
       '@types/node':
         specifier: ^24.0.0
         version: 24.13.2
@@ -288,7 +315,7 @@ importers:
         version: 8.0.16(@types/node@24.13.2)(esbuild@0.27.7)(yaml@2.9.0)
       vite-plugin-dts:
         specifier: ^5.0.0
-        version: 5.0.2(esbuild@0.27.7)(rolldown@1.0.3)(rollup@4.61.1)(typescript@6.0.3)(vite@8.0.16(@types/node@24.13.2)(esbuild@0.27.7)(yaml@2.9.0))
+        version: 5.0.2(@microsoft/api-extractor@7.58.8(@types/node@24.13.2))(esbuild@0.27.7)(rolldown@1.0.3)(rollup@4.61.1)(typescript@6.0.3)(vite@8.0.16(@types/node@24.13.2)(esbuild@0.27.7)(yaml@2.9.0))
       vite-tsconfig-paths:
         specifier: ^6.0.0
         version: 6.1.1(typescript@6.0.3)(vite@8.0.16(@types/node@24.13.2)(esbuild@0.27.7)(yaml@2.9.0))
@@ -740,6 +767,19 @@ packages:
 
   '@jridgewell/trace-mapping@0.3.31':
     resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
+
+  '@microsoft/api-extractor-model@7.33.8':
+    resolution: {integrity: sha512-aIcoQggPyer3B6Ze3usz0YWC/oBwUHfRH5ETUsr+oT2BRA6SfTJl7IKPcPZkX4UR+PohowzW4uMxsvjrn8vm+w==}
+
+  '@microsoft/api-extractor@7.58.8':
+    resolution: {integrity: sha512-Y45rdEvZodD1WBAK9w8Wvqj7k/6z21YOEP8aVNWv1vemEzanjThvCowc3Eyt/bmJJyqI4gj0BQr9nLC51fsDiQ==}
+    hasBin: true
+
+  '@microsoft/tsdoc-config@0.18.1':
+    resolution: {integrity: sha512-9brPoVdfN9k9g0dcWkFeA7IH9bbcttzDJlXvkf8b2OBzd5MueR1V2wkKBL0abn0otvmkHJC6aapBOTJDDeMCZg==}
+
+  '@microsoft/tsdoc@0.16.0':
+    resolution: {integrity: sha512-xgAyonlVVS+q7Vc7qLW0UrJU7rSFcETRWsqdXZtjzRU8dF+6CkozTK4V4y1LwOX7j8r/vHphjDeMeGI4tNGeGA==}
 
   '@napi-rs/wasm-runtime@0.2.4':
     resolution: {integrity: sha512-9zESzOO5aDByvhIAsOy9TbpZ0Ur2AJbUI7UT73kcUTS2mxAMHOBaa1st/jAymNoCtvrit99kkzT1FZuXVcgfIQ==}
@@ -1202,6 +1242,36 @@ packages:
   '@rtsao/scc@1.1.0':
     resolution: {integrity: sha512-zt6OdqaDoOnJ1ZYsCYGt9YmWzDXl4vQdKTyJev62gFhRGKdx7mcT54V9KIjg+d2wi9EXsPvAPKe7i7WjfVWB8g==}
 
+  '@rushstack/node-core-library@5.23.1':
+    resolution: {integrity: sha512-wlKmIKIYCKuCASbITvOxLZXepPbwXvrv7S6ig6XNWFchSyhL/E2txmVXspHY49Wu2dzf7nI27a2k/yV5BA3EiA==}
+    peerDependencies:
+      '@types/node': '*'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@rushstack/problem-matcher@0.2.1':
+    resolution: {integrity: sha512-gulfhBs6n+I5b7DvjKRfhMGyUejtSgOHTclF/eONr8hcgF1APEDjhxIsfdUYYMzC3rvLwGluqLjbwCFZ8nxrog==}
+    peerDependencies:
+      '@types/node': '*'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@rushstack/rig-package@0.7.3':
+    resolution: {integrity: sha512-aAA518n6wxxjCfnTAOjQnm7ngNE0FVHxHAw2pxKlIhxrMn0XQjGcXKF0oKWpjBgJOmsaJpVob/v+zr3zxgPWuA==}
+
+  '@rushstack/terminal@0.24.0':
+    resolution: {integrity: sha512-8ZQS4MMaGsv27EXCBiH7WMPkRZrffeDoIevs6z9TM5dzqiY6+Hn4evfK/G+gvgBTjfvfkHIZPQQmalmI2sM4TQ==}
+    peerDependencies:
+      '@types/node': '*'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@rushstack/ts-command-line@5.3.9':
+    resolution: {integrity: sha512-GIHqU+sRGQ3LGWAZu1O+9Yh++qwtyNIIGuNbcWHJjBTm2qRez0cwINUHZ+pQLR8UuzZDcMajrDaNbUYoaL/XtQ==}
+
   '@sigstore/bundle@4.0.0':
     resolution: {integrity: sha512-NwCl5Y0V6Di0NexvkTqdoVfmjTaQwoLM236r89KEojGmq/jMls8S+zb7yOwAPdXvbwfKDlP+lmXgAL4vKSQT+A==}
     engines: {node: ^20.17.0 || >=22.9.0}
@@ -1275,6 +1345,9 @@ packages:
 
   '@tybys/wasm-util@0.9.0':
     resolution: {integrity: sha512-6+7nlbMVX/PVDCwaIQ8nTOPveOcFLSt8GcXdx8hD0bt39uWxYT88uXzqTd4fTvqta7oeUJqudepapKNt2DYJFw==}
+
+  '@types/argparse@1.0.38':
+    resolution: {integrity: sha512-ebDJ9b0e702Yr7pWgB0jzm+CX4Srzz8RcXtLJDJB+BSccqMa36uyH/zUsSYao5+BD1ytv3k3rPYCq4mAE1hsXA==}
 
   '@types/chai@5.2.3':
     resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
@@ -1449,8 +1522,27 @@ packages:
     resolution: {integrity: sha512-4I7Td01quW/RpocfNayFdFVk1qSuoh0E7JrbRJ16nH01HhKFQ88INq9Sd+nd72zqRySlr9BmDA8xlEJ6vJMrYA==}
     engines: {node: '>=8'}
 
+  ajv-draft-04@1.0.0:
+    resolution: {integrity: sha512-mv00Te6nmYbRp5DCwclxtt7yV/joXJPGS7nM+97GdxvuttCOfgI3K4U25zboyeX0O+myI8ERluxQe5wljMmVIw==}
+    peerDependencies:
+      ajv: ^8.5.0
+    peerDependenciesMeta:
+      ajv:
+        optional: true
+
+  ajv-formats@3.0.1:
+    resolution: {integrity: sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==}
+    peerDependencies:
+      ajv: ^8.0.0
+    peerDependenciesMeta:
+      ajv:
+        optional: true
+
   ajv@6.15.0:
     resolution: {integrity: sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==}
+
+  ajv@8.18.0:
+    resolution: {integrity: sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==}
 
   ansi-colors@4.1.3:
     resolution: {integrity: sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw==}
@@ -1470,6 +1562,9 @@ packages:
 
   aproba@2.0.0:
     resolution: {integrity: sha512-lYe4Gx7QT+MKGbDsA+Z+he/Wtef0BiwDOlK/XkBrdfsh9J/jPPXbX0tE9x9cl27Tmu5gg3QUbUrQYa/y+KOHPQ==}
+
+  argparse@1.0.10:
+    resolution: {integrity: sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==}
 
   argparse@2.0.1:
     resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
@@ -1833,6 +1928,10 @@ packages:
     resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
     engines: {node: '>=8'}
 
+  diff@8.0.4:
+    resolution: {integrity: sha512-DPi0FmjiSU5EvQV0++GFDOJ9ASQUVFh5kD+OzOnYdi7n3Wpm9hWWGfB/O2blfHcMVTL5WkQXSnRiK9makhrcnw==}
+    engines: {node: '>=0.3.1'}
+
   doctrine@2.1.0:
     resolution: {integrity: sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==}
     engines: {node: '>=0.10.0'}
@@ -2045,6 +2144,9 @@ packages:
 
   fast-levenshtein@2.0.6:
     resolution: {integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==}
+
+  fast-uri@3.1.2:
+    resolution: {integrity: sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==}
 
   fdir@6.5.0:
     resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
@@ -2318,6 +2420,10 @@ packages:
     resolution: {integrity: sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==}
     engines: {node: '>=6'}
 
+  import-lazy@4.0.0:
+    resolution: {integrity: sha512-rKtvo6a868b5Hu3heneU+L4yEQ4jYKLtjpnPeUdK7h0yzXGmyBTypknlkCvHFBqfX9YlorEiMM6Dnq/5atfHkw==}
+    engines: {node: '>=8'}
+
   import-local@3.1.0:
     resolution: {integrity: sha512-ASB07uLtnDs1o6EHjKpX34BKYDSqnFerfTOJL2HvMqF70LnxpjkzDB8J44oT9pu4AMPkQwf8jl6szgvNd2tRIg==}
     engines: {node: '>=8'}
@@ -2546,6 +2652,9 @@ packages:
     resolution: {integrity: sha512-CRpFK0RtLriVDGcPPAnR6HMVI8bSR2jnUIgralhauzYQZIb4RH9AtEInTuQr65LmmGggGcRT6HIASxwqsVsmlA==}
     engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
 
+  jju@1.4.0:
+    resolution: {integrity: sha512-8wb9Yw966OSxApiCt0K3yNJL8pnNeIv+OEq2YMidz4FKP6nonSRoOXc80iXY4JaN2FC11B9qsNmDsm+ZOfMROA==}
+
   js-tokens@10.0.0:
     resolution: {integrity: sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==}
 
@@ -2575,6 +2684,9 @@ packages:
 
   json-schema-traverse@0.4.1:
     resolution: {integrity: sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==}
+
+  json-schema-traverse@1.0.0:
+    resolution: {integrity: sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==}
 
   json-stable-stringify-without-jsonify@1.0.1:
     resolution: {integrity: sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==}
@@ -2812,6 +2924,10 @@ packages:
   min-indent@1.0.1:
     resolution: {integrity: sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==}
     engines: {node: '>=4'}
+
+  minimatch@10.2.3:
+    resolution: {integrity: sha512-Rwi3pnapEqirPSbWbrZaa6N3nmqq4Xer/2XooiOKyV3q12ML06f7MOuc5DVH8ONZIFhwIYQ3yzPH4nt7iWHaTg==}
+    engines: {node: 18 || 20 || >=22}
 
   minimatch@10.2.5:
     resolution: {integrity: sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==}
@@ -3330,6 +3446,10 @@ packages:
     resolution: {integrity: sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==}
     engines: {node: '>=0.10.0'}
 
+  require-from-string@2.0.2:
+    resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
+    engines: {node: '>=0.10.0'}
+
   resolve-cwd@3.0.0:
     resolution: {integrity: sha512-OrZaX2Mb+rJCpH/6CpSqt9xFVpN++x01XnN2ie9g6P5/3xelLAkXWVADpdz1IHD/KFfEXyE6V0U01OQ3UO2rEg==}
     engines: {node: '>=8'}
@@ -3521,6 +3641,9 @@ packages:
   split@1.0.1:
     resolution: {integrity: sha512-mTyOoPbrivtXnwnIxZRFYRrPNtEFKlpB2fvjSnCQUiAA6qAZzqwna5envK4uk6OIeP17CsdF3rSBGYVBsU0Tkg==}
 
+  sprintf-js@1.0.3:
+    resolution: {integrity: sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==}
+
   ssri@12.0.0:
     resolution: {integrity: sha512-S7iGNosepx9RadX82oimUkvr0Ct7IjJbEbs4mJcTxst8um95J3sDYU1RBEOvdu6oL1Wek2ODI5i4MAw+dZ6cAQ==}
     engines: {node: ^18.17.0 || >=20.5.0}
@@ -3538,6 +3661,10 @@ packages:
   stop-iteration-iterator@1.1.0:
     resolution: {integrity: sha512-eLoXW/DHyl62zxY4SCaIgnRhuMr6ri4juEYARS8E6sCEqzKpOiE521Ucofdx+KnDZl5xmvGYaaKCk5FEOxJCoQ==}
     engines: {node: '>= 0.4'}
+
+  string-argv@0.3.2:
+    resolution: {integrity: sha512-aqD2Q0144Z+/RqG52NeHEkZauTAUWJO8c6yTftGJKO3Tja5tUgIfmIl6kExvhtxSDP7fXB6DvzkfMpCd/F3G+Q==}
+    engines: {node: '>=0.6.19'}
 
   string-width@4.2.3:
     resolution: {integrity: sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==}
@@ -3584,6 +3711,10 @@ packages:
   supports-color@7.2.0:
     resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
     engines: {node: '>=8'}
+
+  supports-color@8.1.1:
+    resolution: {integrity: sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==}
+    engines: {node: '>=10'}
 
   supports-preserve-symlinks-flag@1.0.0:
     resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}
@@ -4376,6 +4507,41 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
 
+  '@microsoft/api-extractor-model@7.33.8(@types/node@24.13.2)':
+    dependencies:
+      '@microsoft/tsdoc': 0.16.0
+      '@microsoft/tsdoc-config': 0.18.1
+      '@rushstack/node-core-library': 5.23.1(@types/node@24.13.2)
+    transitivePeerDependencies:
+      - '@types/node'
+
+  '@microsoft/api-extractor@7.58.8(@types/node@24.13.2)':
+    dependencies:
+      '@microsoft/api-extractor-model': 7.33.8(@types/node@24.13.2)
+      '@microsoft/tsdoc': 0.16.0
+      '@microsoft/tsdoc-config': 0.18.1
+      '@rushstack/node-core-library': 5.23.1(@types/node@24.13.2)
+      '@rushstack/rig-package': 0.7.3
+      '@rushstack/terminal': 0.24.0(@types/node@24.13.2)
+      '@rushstack/ts-command-line': 5.3.9(@types/node@24.13.2)
+      diff: 8.0.4
+      minimatch: 10.2.3
+      resolve: 1.22.12
+      semver: 7.7.4
+      source-map: 0.6.1
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - '@types/node'
+
+  '@microsoft/tsdoc-config@0.18.1':
+    dependencies:
+      '@microsoft/tsdoc': 0.16.0
+      ajv: 8.18.0
+      jju: 1.4.0
+      resolve: 1.22.12
+
+  '@microsoft/tsdoc@0.16.0': {}
+
   '@napi-rs/wasm-runtime@0.2.4':
     dependencies:
       '@emnapi/core': 1.4.5
@@ -4781,6 +4947,45 @@ snapshots:
 
   '@rtsao/scc@1.1.0': {}
 
+  '@rushstack/node-core-library@5.23.1(@types/node@24.13.2)':
+    dependencies:
+      ajv: 8.18.0
+      ajv-draft-04: 1.0.0(ajv@8.18.0)
+      ajv-formats: 3.0.1(ajv@8.18.0)
+      fs-extra: 11.3.5
+      import-lazy: 4.0.0
+      jju: 1.4.0
+      resolve: 1.22.12
+      semver: 7.7.4
+    optionalDependencies:
+      '@types/node': 24.13.2
+
+  '@rushstack/problem-matcher@0.2.1(@types/node@24.13.2)':
+    optionalDependencies:
+      '@types/node': 24.13.2
+
+  '@rushstack/rig-package@0.7.3':
+    dependencies:
+      jju: 1.4.0
+      resolve: 1.22.12
+
+  '@rushstack/terminal@0.24.0(@types/node@24.13.2)':
+    dependencies:
+      '@rushstack/node-core-library': 5.23.1(@types/node@24.13.2)
+      '@rushstack/problem-matcher': 0.2.1(@types/node@24.13.2)
+      supports-color: 8.1.1
+    optionalDependencies:
+      '@types/node': 24.13.2
+
+  '@rushstack/ts-command-line@5.3.9(@types/node@24.13.2)':
+    dependencies:
+      '@rushstack/terminal': 0.24.0(@types/node@24.13.2)
+      '@types/argparse': 1.0.38
+      argparse: 1.0.10
+      string-argv: 0.3.2
+    transitivePeerDependencies:
+      - '@types/node'
+
   '@sigstore/bundle@4.0.0':
     dependencies:
       '@sigstore/protobuf-specs': 0.5.1
@@ -4850,6 +5055,8 @@ snapshots:
   '@tybys/wasm-util@0.9.0':
     dependencies:
       tslib: 2.8.1
+
+  '@types/argparse@1.0.38': {}
 
   '@types/chai@5.2.3':
     dependencies:
@@ -5062,12 +5269,27 @@ snapshots:
       clean-stack: 2.2.0
       indent-string: 4.0.0
 
+  ajv-draft-04@1.0.0(ajv@8.18.0):
+    optionalDependencies:
+      ajv: 8.18.0
+
+  ajv-formats@3.0.1(ajv@8.18.0):
+    optionalDependencies:
+      ajv: 8.18.0
+
   ajv@6.15.0:
     dependencies:
       fast-deep-equal: 3.1.3
       fast-json-stable-stringify: 2.1.0
       json-schema-traverse: 0.4.1
       uri-js: 4.4.1
+
+  ajv@8.18.0:
+    dependencies:
+      fast-deep-equal: 3.1.3
+      fast-uri: 3.1.2
+      json-schema-traverse: 1.0.0
+      require-from-string: 2.0.2
 
   ansi-colors@4.1.3: {}
 
@@ -5080,6 +5302,10 @@ snapshots:
   ansi-styles@5.2.0: {}
 
   aproba@2.0.0: {}
+
+  argparse@1.0.10:
+    dependencies:
+      sprintf-js: 1.0.3
 
   argparse@2.0.1: {}
 
@@ -5468,6 +5694,8 @@ snapshots:
 
   detect-libc@2.1.2: {}
 
+  diff@8.0.4: {}
+
   doctrine@2.1.0:
     dependencies:
       esutils: 2.0.3
@@ -5782,6 +6010,8 @@ snapshots:
 
   fast-levenshtein@2.0.6: {}
 
+  fast-uri@3.1.2: {}
+
   fdir@6.5.0(picomatch@4.0.4):
     optionalDependencies:
       picomatch: 4.0.4
@@ -6057,6 +6287,8 @@ snapshots:
       parent-module: 1.0.1
       resolve-from: 4.0.0
 
+  import-lazy@4.0.0: {}
+
   import-local@3.1.0:
     dependencies:
       pkg-dir: 4.2.0
@@ -6276,6 +6508,8 @@ snapshots:
       chalk: 4.1.2
       pretty-format: 30.4.1
 
+  jju@1.4.0: {}
+
   js-tokens@10.0.0: {}
 
   js-tokens@4.0.0: {}
@@ -6295,6 +6529,8 @@ snapshots:
   json-parse-even-better-errors@5.0.0: {}
 
   json-schema-traverse@0.4.1: {}
+
+  json-schema-traverse@1.0.0: {}
 
   json-stable-stringify-without-jsonify@1.0.1: {}
 
@@ -6610,6 +6846,10 @@ snapshots:
   mimic-fn@2.1.0: {}
 
   min-indent@1.0.1: {}
+
+  minimatch@10.2.3:
+    dependencies:
+      brace-expansion: 5.0.6
 
   minimatch@10.2.5:
     dependencies:
@@ -7328,6 +7568,8 @@ snapshots:
 
   require-directory@2.1.1: {}
 
+  require-from-string@2.0.2: {}
+
   resolve-cwd@3.0.0:
     dependencies:
       resolve-from: 5.0.0
@@ -7573,6 +7815,8 @@ snapshots:
     dependencies:
       through: 2.3.8
 
+  sprintf-js@1.0.3: {}
+
   ssri@12.0.0:
     dependencies:
       minipass: 7.1.3
@@ -7589,6 +7833,8 @@ snapshots:
     dependencies:
       es-errors: 1.3.0
       internal-slot: 1.1.0
+
+  string-argv@0.3.2: {}
 
   string-width@4.2.3:
     dependencies:
@@ -7643,6 +7889,10 @@ snapshots:
       min-indent: 1.0.1
 
   supports-color@7.2.0:
+    dependencies:
+      has-flag: 4.0.0
+
+  supports-color@8.1.1:
     dependencies:
       has-flag: 4.0.0
 
@@ -7817,7 +8067,7 @@ snapshots:
 
   universalify@2.0.1: {}
 
-  unplugin-dts@1.0.2(esbuild@0.27.7)(rolldown@1.0.3)(rollup@4.61.1)(typescript@6.0.3)(vite@8.0.16(@types/node@24.13.2)(esbuild@0.27.7)(yaml@2.9.0)):
+  unplugin-dts@1.0.2(@microsoft/api-extractor@7.58.8(@types/node@24.13.2))(esbuild@0.27.7)(rolldown@1.0.3)(rollup@4.61.1)(typescript@6.0.3)(vite@8.0.16(@types/node@24.13.2)(esbuild@0.27.7)(yaml@2.9.0)):
     dependencies:
       '@rollup/pluginutils': 5.4.0(rollup@4.61.1)
       '@volar/typescript': 2.4.28
@@ -7829,6 +8079,7 @@ snapshots:
       typescript: 6.0.3
       unplugin: 2.3.11
     optionalDependencies:
+      '@microsoft/api-extractor': 7.58.8(@types/node@24.13.2)
       esbuild: 0.27.7
       rolldown: 1.0.3
       rollup: 4.61.1
@@ -7858,10 +8109,11 @@ snapshots:
 
   validate-npm-package-name@6.0.2: {}
 
-  vite-plugin-dts@5.0.2(esbuild@0.27.7)(rolldown@1.0.3)(rollup@4.61.1)(typescript@6.0.3)(vite@8.0.16(@types/node@24.13.2)(esbuild@0.27.7)(yaml@2.9.0)):
+  vite-plugin-dts@5.0.2(@microsoft/api-extractor@7.58.8(@types/node@24.13.2))(esbuild@0.27.7)(rolldown@1.0.3)(rollup@4.61.1)(typescript@6.0.3)(vite@8.0.16(@types/node@24.13.2)(esbuild@0.27.7)(yaml@2.9.0)):
     dependencies:
-      unplugin-dts: 1.0.2(esbuild@0.27.7)(rolldown@1.0.3)(rollup@4.61.1)(typescript@6.0.3)(vite@8.0.16(@types/node@24.13.2)(esbuild@0.27.7)(yaml@2.9.0))
+      unplugin-dts: 1.0.2(@microsoft/api-extractor@7.58.8(@types/node@24.13.2))(esbuild@0.27.7)(rolldown@1.0.3)(rollup@4.61.1)(typescript@6.0.3)(vite@8.0.16(@types/node@24.13.2)(esbuild@0.27.7)(yaml@2.9.0))
     optionalDependencies:
+      '@microsoft/api-extractor': 7.58.8(@types/node@24.13.2)
       rollup: 4.61.1
       vite: 8.0.16(@types/node@24.13.2)(esbuild@0.27.7)(yaml@2.9.0)
     transitivePeerDependencies:


### PR DESCRIPTION
## TL;DR

The renovate bump to `vite-plugin-dts` v5 (and Vite 8) silently broke `.d.ts` generation for **every** package. `prepack` kept exiting `0`, so it went unnoticed until the canary `rc` releases shipped with the `types` files referenced in their `exports` either missing entirely or emitted as empty `export {}` stubs. No stable release was affected.

This restores complete, bundled type declarations for all packages and clears the misleading `TS6059` errors that were spewing on every build.

## Root cause

Three coupled regressions, all from the v5 migration:

1. **Option renamed.** v5 moved its core into `unplugin-dts`, which renamed `rollupTypes` → `bundleTypes`. The old option was silently ignored, so nothing was bundled — packages emitted unrolled per-file declarations (plus leaked test `.d.ts`) under `dist/src/` instead of the single `dist/<name>.d.ts` the `exports` point at.
2. **api-extractor no longer bundled.** v4 shipped `@microsoft/api-extractor` as a direct dependency; v5 demoted it to an optional peer, so pnpm stopped installing it. With it absent, `bundleTypes` silently skips the rollup step.
3. **Entry/rootDir mismatch.** Even with the above fixed, the bundler looked for the entry declaration at a `src`-stripped path while tsc emitted it under `dist/src/`, so the generated types entry was an empty `export {}` and api-extractor bundled nothing. `rootDir: 'src'` flattens the emit so the entry resolves.

Separately, the **`TS6059` errors despite `exit 0`** came from the dev-only tsconfig `paths` (workspace source imports, added in 93e2dad "only for local development and automated tests") leaking into the production dts build, making tsc follow sibling sources outside `rootDir`. The build never failed because `vite-plugin-dts` runs the TS compiler API in-process and only *logs* diagnostics — it never throws or sets a non-zero exit code (and forces `noEmitOnError: undefined`).

## The fix

Each `vite.config.ts` now uses:

```ts
dts({
  bundleTypes: true,
  pathsToAliases: false,
  compilerOptions: { paths: {}, rootDir: 'src' },
}),
```

- `bundleTypes: true` — the v5 name for `rollupTypes`.
- `compilerOptions.paths: {}` — drops the dev-only path mappings for the dts build so `@holz/*` resolves to the built packages (correct, since they stay external in the output) and the `TS6059` noise disappears. The tsconfig keeps `paths` intact for editors and `test:types`.
- `compilerOptions.rootDir: 'src'` — flattens the declaration emit so the bundler entry resolves (fixes the empty `export {}`).
- `@microsoft/api-extractor@^7.58.8` added as a per-package devDependency, alongside the existing `vite-plugin-dts`.

## Verification

- Clean topological `pnpm -r run prepack` exits `0` with **zero TS errors / zero skipped bundles**.
- Every package emits exactly the `.d.ts` its `exports` declare, with complete content (e.g. `holz-core.d.ts` ~6 KB; logger correctly `import { Logger } from '@holz/core'`).
- Full `pnpm test` passes (20/20).

## Pros

- Published packages ship working, bundled types again.
- Build logs are clean — no more misleading `TS6059` errors.
- Dev-only path mappings no longer leak into production artifacts.

## Cons / trade-offs

- The dts build now depends on topological order (a package's deps must be built first so their `.d.ts` exist). This already holds for `pnpm -r` and the release flow, but isolated single-package `prepack` outside that ordering would warn.
- `@microsoft/api-extractor` bundles TS 5.9.3 while the repo is on 6.0.3, so each build prints a benign `consider upgrading API Extractor` notice.

## Recommended follow-up

- **Output-assertion guardrail:** add a post-`prepack` CI check that every `exports` `types` target exists and is non-empty. `vite-plugin-dts` fails open (logs, never errors), so this is the real backstop — it would have caught all three regressions here regardless of cause.
- Track an `@microsoft/api-extractor` bump once it supports TS 6.x to drop the version-mismatch notice.