### PR TITLE
🤖 Offload builds and coverage to turbo

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,10 +7,9 @@
   "license": "MIT",
   "packageManager": "pnpm@11.5.2",
   "scripts": {
-    "prepare": "pnpm -r run prepack",
-    "check": "turbo run test:types test:unit lint fmt-check",
+    "check": "turbo run prepack test:types test:unit lint fmt-check",
     "test": "pnpm check",
-    "test:coverage": "pnpm -r run test:unit -- --coverage --no-watch",
+    "test:coverage": "turbo run test:coverage",
     "lint": "eslint packages/*/src --ext ts,tsx --color --cache --cache-location node_modules/.cache/eslint/",
     "fmt-check": "treefmt --ci",
     "release:candidate": "lerna publish --canary --preid rc --dist-tag rc --force-publish --yes"

--- a/package.json
+++ b/package.json
@@ -8,7 +8,6 @@
   "packageManager": "pnpm@11.5.2",
   "scripts": {
     "check": "turbo run prepack test:types test:unit lint fmt-check",
-    "test": "pnpm check",
     "test:coverage": "turbo run test:coverage",
     "lint": "eslint packages/*/src --ext ts,tsx --color --cache --cache-location node_modules/.cache/eslint/",
     "fmt-check": "treefmt --ci",

--- a/packages/holz-ansi-terminal-backend/package.json
+++ b/packages/holz-ansi-terminal-backend/package.json
@@ -32,6 +32,7 @@
   "scripts": {
     "prepack": "vite build",
     "test:unit": "vitest run --color --passWithNoTests",
+    "test:coverage": "vitest run --coverage --color --passWithNoTests",
     "test:types": "tsc"
   },
   "peerDependencies": {

--- a/packages/holz-console-backend/package.json
+++ b/packages/holz-console-backend/package.json
@@ -33,6 +33,7 @@
   "scripts": {
     "prepack": "vite build",
     "test:unit": "vitest run --color --passWithNoTests",
+    "test:coverage": "vitest run --coverage --color --passWithNoTests",
     "test:types": "tsc"
   },
   "peerDependencies": {

--- a/packages/holz-core/package.json
+++ b/packages/holz-core/package.json
@@ -32,6 +32,7 @@
   "scripts": {
     "prepack": "vite build",
     "test:unit": "vitest run --color --passWithNoTests",
+    "test:coverage": "vitest run --coverage --color --passWithNoTests",
     "test:types": "tsc"
   },
   "devDependencies": {

--- a/packages/holz-env-filter/package.json
+++ b/packages/holz-env-filter/package.json
@@ -34,6 +34,7 @@
   "scripts": {
     "prepack": "vite build",
     "test:unit": "vitest run --color --passWithNoTests",
+    "test:coverage": "vitest run --coverage --color --passWithNoTests",
     "test:types": "tsc"
   },
   "dependencies": {

--- a/packages/holz-json-backend/package.json
+++ b/packages/holz-json-backend/package.json
@@ -33,6 +33,7 @@
   "scripts": {
     "prepack": "vite build",
     "test:unit": "vitest run --color --passWithNoTests",
+    "test:coverage": "vitest run --coverage --color --passWithNoTests",
     "test:types": "tsc"
   },
   "devDependencies": {

--- a/packages/holz-log-collector/package.json
+++ b/packages/holz-log-collector/package.json
@@ -33,6 +33,7 @@
   "scripts": {
     "prepack": "vite build",
     "test:unit": "vitest run --color --passWithNoTests",
+    "test:coverage": "vitest run --coverage --color --passWithNoTests",
     "test:types": "tsc"
   },
   "peerDependencies": {

--- a/packages/holz-logger/package.json
+++ b/packages/holz-logger/package.json
@@ -42,6 +42,7 @@
   "scripts": {
     "prepack": "vite build",
     "test:unit": "vitest run --color --passWithNoTests",
+    "test:coverage": "vitest run --coverage --color --passWithNoTests",
     "test:types": "tsc"
   },
   "dependencies": {

--- a/packages/holz-pattern-filter/package.json
+++ b/packages/holz-pattern-filter/package.json
@@ -34,6 +34,7 @@
   "scripts": {
     "prepack": "vite build",
     "test:unit": "vitest run --color --passWithNoTests",
+    "test:coverage": "vitest run --coverage --color --passWithNoTests",
     "test:types": "tsc"
   },
   "peerDependencies": {

--- a/packages/holz-stream-backend/package.json
+++ b/packages/holz-stream-backend/package.json
@@ -33,6 +33,7 @@
   "scripts": {
     "prepack": "vite build",
     "test:unit": "vitest run --color --passWithNoTests",
+    "test:coverage": "vitest run --coverage --color --passWithNoTests",
     "test:types": "tsc"
   },
   "peerDependencies": {

--- a/turbo.json
+++ b/turbo.json
@@ -4,6 +4,11 @@
   "globalDependencies": ["tsconfig.json"],
   "globalPassThroughEnv": ["FORCE_COLOR", "CLICOLOR_FORCE"],
   "tasks": {
+    "prepack": {
+      "dependsOn": ["^prepack"],
+      "outputs": ["dist/**"],
+      "outputLogs": "errors-only"
+    },
     "test:types": {
       "dependsOn": ["^test:types"],
       "outputs": [],
@@ -12,6 +17,11 @@
     "test:unit": {
       "dependsOn": ["^test:types"],
       "outputs": [],
+      "outputLogs": "errors-only"
+    },
+    "test:coverage": {
+      "dependsOn": ["^test:types"],
+      "outputs": ["coverage/**"],
       "outputLogs": "errors-only"
     },
     "//#lint": {


### PR DESCRIPTION
## TL;DR:

Package builds and the coverage run were still invoked via `pnpm -r`, sidestepping turbo's caching and dependency-graph orchestration that the type-check/unit/lint/fmt tasks already use. This moves both onto turbo and removes the redundant `test` script alias.

## Changes

- **Builds → turbo.** New `prepack` task (`dependsOn: ["^prepack"]`, `outputs: ["dist/**"]`), run as part of `pnpm check` alongside the type/unit/lint/fmt tasks in a single `turbo run`. Topological ordering matters because dts bundling resolves each dependency's types through its built `dist/*.d.ts`. The per-package `prepack` script is untouched, so it still fires as the publish lifecycle hook and `lerna publish` keeps auto-building.
- **Coverage → turbo.** New dedicated `test:coverage` task (`outputs: ["coverage/**"]`) with matching per-package scripts; root `test:coverage` runs `turbo run test:coverage`. A separate task (rather than threading `--coverage` through the shared `test:unit`) keeps the common `check` path free of turbo's "no output files found" warning and lets coverage cache + restore correctly.
- **Drop the `test` alias.** `test` was just `pnpm check`; standardized on `pnpm check`. Nothing referenced `pnpm test` — both GHA workflows already call `pnpm check`.

## Why the build lives in `check`, not `prepare`

The build previously ran from the root `prepare` lifecycle (on every `pnpm install`). The first cut of this PR kept that, just swapping `pnpm -r run prepack` for `turbo run prepack` — and CI hung indefinitely on the install step. A `turbo run` nested inside pnpm's install lifecycle hangs in CI, even though the identical `turbo run` from a normal script step (`pnpm check`) runs fine. Folding the build into `check` keeps build verification in CI (and locally) without the hang, and `prepare` is dropped entirely.

## Verification

- `pnpm check` from a cold cache: 29 tasks (9 builds + 9 type-checks + 9 unit + lint + fmt), all green, ~32s; re-run is `>>> FULL TURBO`. Produces correct `.js`/`.cjs`/bundled `.d.ts` per package (logger gets browser + server).
- `pnpm test:coverage`: produces all 9 `coverage/` dirs; cache hit restores them.

## Pros

- Build, coverage, type-check, unit, lint, and fmt all run through turbo with caching (and the existing CI `.turbo` cache), with correct topological ordering enforced declaratively.
- One canonical command surface (`pnpm check`), no duplicate alias, no install-lifecycle build.

## Cons

- `pnpm check` now produces build artifacts (`dist/`) as a side effect. It's gitignored and excluded from fmt/lint, but `check` is no longer purely read-only.
- `pnpm install` no longer pre-builds packages. Nothing in-workspace needs `dist` (intra-repo resolution uses source via tsconfig paths), so this is a non-issue in practice, but a consumer relying on a freshly-installed `dist` would now need to run `pnpm check` (or publish).

## Recommended follow-up

- Consider a turbo remote cache (or sharing `.turbo` more aggressively in CI) so build/coverage cache hits carry across machines, not just within a checkout.
- The release workflow still relies on the per-package `prepack` lifecycle hook for publish builds; could later route that through turbo too for consistency, though it isn't necessary.
