### PR TITLE
Revert @holz/json-backend to a Node Writable stream

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 - **AI disclosure:** Holz was built with Aider and Claude from the start. Agents will increasingly contribute, but quality remains a priority.
 - `[@holz/json-backend]` Entries now include `log.owner`.
-- `[@holz/json-backend]` New optional `signal` option. Pass an `AbortSignal` to close the stream on shutdown, flushing queued writes.
 
 ### Fixed
 
@@ -19,7 +18,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Changed
 
 - `[@holz/json-backend]` The platform-specific `\r\n` was dropped for better portability. All systems write `\n` as the newline character.
-- `[@holz/json-backend]` Expects a WHATWG [WritableStream](https://developer.mozilla.org/en-US/docs/Web/API/WritableStream) instead of a Node Streams interface. Improves portability, particularly for browser environments.
 
 ## [0.8.2] - 2025-05-28
 

--- a/packages/holz-json-backend/README.md
+++ b/packages/holz-json-backend/README.md
@@ -7,11 +7,11 @@ Prints structured logs to a writable stream in NDJSON form.
 ```typescript
 import { createJsonBackend } from '@holz/json-backend';
 import { createLogger } from '@holz/core';
-import * as fs from 'node:fs';
+import { createWriteStream } from 'node:fs';
 
 const logger = createLogger(
   createJsonBackend({
-    stream: fs.createWriteStream('my-app.log', { flags: 'a' }),
+    stream: createWriteStream('my-logs.ndjson', { flags: 'a' }),
   }),
 );
 ```
@@ -19,3 +19,9 @@ const logger = createLogger(
 Logs are output in [NDJSON](https://github.com/ndjson/ndjson-spec) format. The output is optimized for log files, following the order of typical log statements. The output includes the log level, timestamp, message, and context, if provided.
 
 The `stream` option specifies where the logs will be written to. You can use any writable stream, such as a file or `process.stdout`.
+
+## Log Rotation
+
+Long-lived processes or noisy services can fill up the disk, given enough time.
+
+Lean on your environment's tools (`journalctl`) or use a package like [rotating-file-stream](https://github.com/iccicci/rotating-file-stream) to prevent files from growing unbounded.

--- a/packages/holz-json-backend/README.md
+++ b/packages/holz-json-backend/README.md
@@ -1,66 +1,21 @@
 # `@holz/json-backend`
 
-Serializes structured logs to a writable stream in [NDJSON](https://github.com/ndjson/ndjson-spec) format.
+Prints structured logs to a writable stream in NDJSON form.
 
 ## Usage
-
-This backend serializes logs into a [`WritableStream<Uint8Array>`](https://developer.mozilla.org/en-US/docs/Web/API/WritableStream). Each chunk is UTF-8 encoded. Ideal for append-only log files.
-
-Target environments are servers, host endpoints, and browsers (via [OPFS](https://developer.mozilla.org/en-US/docs/Web/API/FileSystemFileHandle/createWritable)).
 
 ```typescript
 import { createJsonBackend } from '@holz/json-backend';
 import { createLogger } from '@holz/core';
+import * as fs from 'node:fs';
 
 const logger = createLogger(
   createJsonBackend({
-    stream: new WritableStream<Uint8Array>(
-      {
-        // ...
-      },
-      new CountQueuingStrategy({
-        highWaterMark: 1024,
-      }),
-    ),
+    stream: fs.createWriteStream('my-app.log', { flags: 'a' }),
   }),
 );
 ```
 
-### Node Streams
+Logs are output in [NDJSON](https://github.com/ndjson/ndjson-spec) format. The output is optimized for log files, following the order of typical log statements. The output includes the log level, timestamp, message, and context, if provided.
 
-Node's streams shipped long before the web standard and need to be wrapped with [Writable.toWeb](https://nodejs.org/api/stream.html#streamwritabletowebstreamwritable):
-
-```typescript
-import { createWriteStream } from 'node:fs';
-import { Writable } from 'node:stream';
-
-createJsonBackend({
-  stream: Writable.toWeb(createWriteStream('logs.ndjson', { flags: 'a' })),
-}),
-```
-
-The same adapter works for any Node writable, including `process.stderr`.
-
-### Closing the Stream
-
-By default, the stream remains open forever. Pass an [AbortSignal](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal) to control the shutdown.
-
-```typescript
-const controller = new AbortController();
-
-createJsonBackend({
-  stream: writableStream,
-  signal: controller.signal,
-});
-
-// Permanently close the writable stream.
-controller.abort();
-```
-
-Tap the stream's [close](https://developer.mozilla.org/en-US/docs/Web/API/WritableStream/WritableStream#closecontroller) handler or node's [finish](https://nodejs.org/api/fs.html#event-finish) event for a clean shutdown.
-
-## Caveats
-
-- Writes are fire-and-forget. Stream backpressure from an overwhelmed sink will cause logs to be dropped. Use [CountQueuingStrategy](https://developer.mozilla.org/en-US/docs/Web/API/CountQueuingStrategy) to adjust the log buffer.
-- Long-running processes and noisy services create giant files. Lean on your environment's tools (`journalctl`) or use a package like [rotating-file-stream](https://github.com/iccicci/rotating-file-stream).
-- OPFS streams in browser environments have poor durability. You may need synchronous access to periodically flush writes, an API only available in workers.
+The `stream` option specifies where the logs will be written to. You can use any writable stream, such as a file or `process.stdout`.

--- a/packages/holz-json-backend/src/__tests__/json-backend.test.ts
+++ b/packages/holz-json-backend/src/__tests__/json-backend.test.ts
@@ -1,3 +1,4 @@
+import { Writable } from 'node:stream';
 import { createLogger } from '@holz/core';
 import { createJsonBackend } from '../json-backend';
 
@@ -6,42 +7,32 @@ const CURRENT_TIME = new Date('2020-06-15T12:00:00.000Z');
 describe('JSON backend', () => {
   const createStream = () => {
     let output = '';
-    const closed = Promise.withResolvers<void>();
-    const decoder = new TextDecoder();
-    const controller = new AbortController();
-
-    const stream = new WritableStream<Uint8Array>(
-      {
-        write(chunk) {
-          output += decoder.decode(chunk);
-        },
-        close() {
-          closed.resolve();
-        },
+    const stream = new Writable({
+      write(chunk, _encoding, callback) {
+        output += String(chunk);
+        callback();
       },
-      // A generous queue mirrors the buffering of real file streams, so the
-      // backend's backpressure guard doesn't drop a synchronous burst of logs.
-      new CountQueuingStrategy({ highWaterMark: 1024 }),
-    );
+    });
 
-    // Aborting tells the backend to close the writer. Once the queued writes
-    // drain, the sink's `close` fires and the captured output is final.
-    const getOutput = async () => {
-      controller.abort();
-      await closed.promise;
-      return output;
+    return {
+      getOutput: () => output,
+      stream,
     };
-
-    return { stream, signal: controller.signal, getOutput };
   };
 
   beforeEach(() => {
-    vi.useFakeTimers({ now: CURRENT_TIME });
+    vi.useFakeTimers({
+      now: CURRENT_TIME,
+    });
   });
 
-  it('prints the logs to the writable stream', async () => {
-    const { stream, signal, getOutput } = createStream();
-    const backend = createJsonBackend({ stream, signal });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('prints the logs to the writable stream', () => {
+    const { stream, getOutput } = createStream();
+    const backend = createJsonBackend({ stream });
 
     const logger = createLogger(backend);
     logger.debug('shout');
@@ -49,75 +40,49 @@ describe('JSON backend', () => {
     logger.warn('hmmmm');
     logger.error('oh no');
 
-    expect(await getOutput()).toMatchSnapshot();
+    expect(getOutput()).toMatchSnapshot();
   });
 
-  it('drops logs when the sink applies backpressure', async () => {
-    let output = '';
-    const wrote = Promise.withResolvers<void>();
-    const decoder = new TextDecoder();
-
-    // A write that never settles keeps the stream saturated, so `desiredSize`
-    // stays exhausted and the backend drops rather than buffers.
-    const stalled = new Promise<void>(() => {});
-    const stream = new WritableStream<Uint8Array>({
-      write(chunk) {
-        output += decoder.decode(chunk);
-        wrote.resolve();
-        return stalled;
-      },
-    });
-    const logger = createLogger(createJsonBackend({ stream }));
-
-    for (let iteration = 0; iteration < 100; iteration += 1) {
-      logger.info('overwhelming the sink');
-    }
-
-    await wrote.promise;
-    const lineCount = output.split('\n').filter(Boolean).length;
-    expect(lineCount).toBeGreaterThan(0);
-    expect(lineCount).toBeLessThan(100);
-  });
-
-  it('escapes newlines and carriage returns', async () => {
-    const { stream, signal, getOutput } = createStream();
-    const backend = createJsonBackend({ stream, signal });
+  it('escapes newlines and carriage returns', () => {
+    const { stream, getOutput } = createStream();
+    const backend = createJsonBackend({ stream });
     const logger = createLogger(backend);
 
     logger.debug('sneaky log\nwith newlines\rand carriage returns\r\n');
 
-    expect(await getOutput()).toContain(
+    expect(getOutput()).toContain(
       'sneaky log\\nwith newlines\\rand carriage returns\\r\\n',
     );
   });
 
-  it('includes log context', async () => {
-    const { stream, signal, getOutput } = createStream();
-    const backend = createJsonBackend({ stream, signal });
+  it('includes log context', () => {
+    const { stream, getOutput } = createStream();
+    const backend = createJsonBackend({ stream });
     const logger = createLogger(backend);
 
     logger.debug('hello', { reqId: 'abc' });
 
-    expect(await getOutput()).toContain('"reqId":"abc"');
+    expect(getOutput()).toContain('"reqId":"abc"');
   });
 
-  it('pulls structure from errors', async () => {
-    const { stream, signal, getOutput } = createStream();
-    const backend = createJsonBackend({ stream, signal });
+  it('pulls structure from errors', () => {
+    const { stream, getOutput } = createStream();
+    const backend = createJsonBackend({ stream });
     const logger = createLogger(backend);
 
     logger.error('content', {
       error: new RangeError('Testing NDJSON errors'),
     });
 
-    expect(await getOutput()).toContain(
+    const output = getOutput();
+    expect(output).toContain(
       '"error":{"name":"RangeError","message":"Testing NDJSON errors"}',
     );
   });
 
-  it('detects and includes error causes', async () => {
-    const { stream, signal, getOutput } = createStream();
-    const backend = createJsonBackend({ stream, signal });
+  it('detects and includes error causes', () => {
+    const { stream, getOutput } = createStream();
+    const backend = createJsonBackend({ stream });
     const logger = createLogger(backend);
 
     logger.error('content', {
@@ -126,14 +91,15 @@ describe('JSON backend', () => {
       }),
     });
 
-    expect(await getOutput()).toContain(
+    const output = getOutput();
+    expect(output).toContain(
       '"error":{"name":"Error","message":"Testing NDJSON errors","cause":{"name":"Error","message":"Cause"}}',
     );
   });
 
-  it('serializes a cause that is not an error', async () => {
-    const { stream, signal, getOutput } = createStream();
-    const backend = createJsonBackend({ stream, signal });
+  it('serializes a cause that is not an error', () => {
+    const { stream, getOutput } = createStream();
+    const backend = createJsonBackend({ stream });
     const logger = createLogger(backend);
 
     logger.error('content', {
@@ -142,28 +108,28 @@ describe('JSON backend', () => {
       }),
     });
 
-    expect(await getOutput()).toContain(
+    expect(getOutput()).toContain(
       '"error":{"name":"Error","message":"Testing NDJSON errors","cause":{"code":"EACCES","retryable":false}}',
     );
   });
 
-  it('serializes a primitive cause', async () => {
-    const { stream, signal, getOutput } = createStream();
-    const backend = createJsonBackend({ stream, signal });
+  it('serializes a primitive cause', () => {
+    const { stream, getOutput } = createStream();
+    const backend = createJsonBackend({ stream });
     const logger = createLogger(backend);
 
     logger.error('content', {
       error: new Error('Testing NDJSON errors', { cause: 'plain string' }),
     });
 
-    expect(await getOutput()).toContain(
+    expect(getOutput()).toContain(
       '"error":{"name":"Error","message":"Testing NDJSON errors","cause":"plain string"}',
     );
   });
 
-  it('unpacks the constituent errors of an AggregateError', async () => {
-    const { stream, signal, getOutput } = createStream();
-    const backend = createJsonBackend({ stream, signal });
+  it('unpacks the constituent errors of an AggregateError', () => {
+    const { stream, getOutput } = createStream();
+    const backend = createJsonBackend({ stream });
     const logger = createLogger(backend);
 
     logger.error('content', {
@@ -173,14 +139,14 @@ describe('JSON backend', () => {
       ),
     });
 
-    expect(await getOutput()).toContain(
+    expect(getOutput()).toContain(
       '"error":{"name":"AggregateError","message":"Everything failed","errors":[{"name":"Error","message":"First failure"},{"name":"TypeError","message":"Second failure"}]}',
     );
   });
 
-  it('detects a cause alongside an AggregateError', async () => {
-    const { stream, signal, getOutput } = createStream();
-    const backend = createJsonBackend({ stream, signal });
+  it('detects a cause alongside an AggregateError', () => {
+    const { stream, getOutput } = createStream();
+    const backend = createJsonBackend({ stream });
     const logger = createLogger(backend);
 
     logger.error('content', {
@@ -189,25 +155,26 @@ describe('JSON backend', () => {
       }),
     });
 
-    expect(await getOutput()).toContain(
+    expect(getOutput()).toContain(
       '"error":{"name":"AggregateError","message":"Outer","cause":{"name":"Error","message":"Root cause"},"errors":[{"name":"Error","message":"Inner"}]}',
     );
   });
 
-  it('includes any enumerable properties on the object', async () => {
+  it('includes any enumerable properties on the object', () => {
     class CustomError extends Error {
       name = 'CustomError';
       status = 418;
     }
 
-    const { stream, signal, getOutput } = createStream();
-    const backend = createJsonBackend({ stream, signal });
+    const { stream, getOutput } = createStream();
+    const backend = createJsonBackend({ stream });
     const logger = createLogger(backend);
 
     logger.error('content', {
       error: new CustomError('Testing NDJSON errors'),
     });
 
-    expect(await getOutput()).toContain('"status":418');
+    const output = getOutput();
+    expect(output).toContain('"status":418');
   });
 });

--- a/packages/holz-json-backend/src/json-backend.ts
+++ b/packages/holz-json-backend/src/json-backend.ts
@@ -1,50 +1,19 @@
+import type { Writable } from 'node:stream';
 import { level, type LogLevel, type Log, type LogProcessor } from '@holz/core';
-
-const encoder = new TextEncoder();
 
 /**
  * Prints structured logs to a writable stream in NDJSON form. Optimized for
  * log files.
  *
- * Writes to a Web Streams `WritableStream<Uint8Array>` so the same backend
- * runs across Node, Deno, Bun, and the browser (e.g. OPFS). See the readme
- * for a Node file-stream example.
- *
  * @example
  * createJsonBackend({
- *   stream: new WritableStream({
- *     write: (chunk) => void process.stdout.write(chunk),
- *   }),
+ *   stream: fs.createWriteStream('my-app.log', { flags: 'a' }),
  * })
  *
- * @see https://github.com/ndjson/ndjson-spec
+ * @see http://ndjson.org
  */
-export const createJsonBackend = ({ stream, signal }: Config): LogProcessor => {
-  const writer = stream.getWriter();
-
-  // Flush and release the writer when the caller signals shutdown. We close
-  // gracefully rather than `abort` so queued writes drain and OPFS-style sinks
-  // commit their data instead of discarding it. This is fire-and-forget: a
-  // caller needing to await the flush should observe its own sink or resource
-  // completion. Once closed, `desiredSize` is null and the guard below drops
-  // any further logs.
-  if (signal?.aborted) {
-    writer.close().catch(noop);
-  } else {
-    signal?.addEventListener('abort', () => void writer.close().catch(noop), {
-      once: true,
-    });
-  }
-
+export const createJsonBackend = ({ stream }: Config): LogProcessor => {
   return (log: Log) => {
-    // Drop logs when the sink is overwhelmed rather than buffering them. We
-    // can't slow down the application, and an unbounded queue would risk
-    // exhausting memory and crashing the process. Losing logs is the better
-    // failure mode. `desiredSize` is null once the stream errors or closes.
-    if (writer.desiredSize === null || writer.desiredSize <= 0) {
-      return;
-    }
-
     // Follow the order of typical log statements. Be kind to the human
     // reader.
     const output = JSON.stringify(
@@ -58,16 +27,15 @@ export const createJsonBackend = ({ stream, signal }: Config): LogProcessor => {
       errorSerializer,
     );
 
-    // NOTE: Fire-and-forget. We deliberately don't await the write - stalling
-    // an application on logging would be a poor tradeoff. The returned promise
-    // is ignored, with a no-op catch to avoid unhandled rejections if the sink
-    // errors (e.g. a closed stream).
-    writer.write(encoder.encode(`${output}\n`)).catch(noop);
+    // NOTE: If the stream applies backpressure, we will lose logs. I believe
+    // this is the right tradeoff. We can't prevent the app from generating
+    // more logs, and if we buffered it would risk running out of memory and
+    // crashing the process.
+    //
+    // It is unlikely that a file or tty will apply backpressure in practice.
+    stream.write(`${output}\n`);
   };
 };
-
-/** Swallows a rejected write so it doesn't surface as an unhandled rejection. */
-const noop = () => {};
 
 /**
  * Errors are not JSON serializable, but errors are naturally a crucial aspect
@@ -100,13 +68,6 @@ const labelForLevel = Object.fromEntries(
 ) as Record<LogLevel, string>;
 
 interface Config {
-  /** Where to print logs. Each log is written as a line of UTF-8 NDJSON. */
-  stream: WritableStream<Uint8Array>;
-
-  /**
-   * Closes the stream on abort, flushing queued writes and committing
-   * OPFS-style sinks. Fire-and-forget: to await the flush, observe your own
-   * sink or resource completion. Logs are dropped once shutdown begins.
-   */
-  signal?: AbortSignal;
+  /** Where to print logs. */
+  stream: Writable;
 }

--- a/packages/holz-json-backend/src/json-backend.ts
+++ b/packages/holz-json-backend/src/json-backend.ts
@@ -10,7 +10,7 @@ import { level, type LogLevel, type Log, type LogProcessor } from '@holz/core';
  *   stream: fs.createWriteStream('my-app.log', { flags: 'a' }),
  * })
  *
- * @see http://ndjson.org
+ * @see https://github.com/ndjson/ndjson-spec
  */
 export const createJsonBackend = ({ stream }: Config): LogProcessor => {
   return (log: Log) => {


### PR DESCRIPTION
Human here :wave: 

I switched `@holz/json-backend` to expect a web stream for the sake of experimenting with [OPFS](https://developer.mozilla.org/en-US/docs/Web/API/File_System_API/Origin_private_file_system). Having real NDJSON log files in the browser sounded nice. Easily exported or moved with [showDirectoryPicker](https://developer.mozilla.org/en-US/docs/Web/API/Window/showDirectoryPicker).

I tried. It was **terrible**. Do not recommend.

This PR reverts 20ae061 back to the Node Streams API. There are too many sharp edges.

Below is a rambling post about all the ways the experiment failed.

## Issues

The async API doesn't guarantee durability. Logs streamed to [createWritable](https://developer.mozilla.org/en-US/docs/Web/API/FileSystemFileHandle/createWritable) only persist when the stream is closed. If the tab exits early or dies, the entire session is lost.

What if you watched [pagehide](https://developer.mozilla.org/en-US/docs/Web/API/Window/pagehide_event) to close/resume and accept that it's best effort? Again, bad idea. Opening existing files in append mode **copies everything to a tempfile**. This could be KB of logs copied as soon as your app starts.

OPFS supports durable writes and real appends via [createSyncAccessHandle](https://developer.mozilla.org/en-US/docs/Web/API/FileSystemFileHandle/createSyncAccessHandle). It's only available in dedicated workers, but that seems reasonable! Launch a worker, stream your logs there, and periodically [flush](https://developer.mozilla.org/en-US/docs/Web/API/FileSystemSyncAccessHandle/flush). Real durability, no copy-on-load.

It works for simple cases. It means every tab needs its own log file (sync handles are exclusive locks), but it works.

> [!NOTE]
> [SharedWorker](https://developer.mozilla.org/en-US/docs/Web/API/SharedWorker/SharedWorker) would be perfect if it supported synchronous OPFS handles. It does not.

It gets super weird with Service Workers. Where should service worker logs go? There's not always a corresponding tab. There might not even *be* a tab. And it's not like the tab's log file is the right place anyway.

Service Workers have access to async OPFS. They could write as non-durable streams. But non-durable is even more dangerous here, as there's no event indicating it's about to shut down and browsers aggressively kill and restart them.

Dedicated Workers are another paper cut. They can't message each other. They need to relay a [MessageChannel](https://developer.mozilla.org/en-US/docs/Web/API/MessageChannel/MessageChannel) to the logging worker through the main process. Logging concerns start leaking everywhere.

(Not to mention the logging worker has to detect its own process and write logs to itself.)

By this point I'm pursuing it out of spite. It's clearly a bad direction, but I wanted to know what it would take to do it "right".

## Persisting Logs: Single File with Leader Election

- Each tab queries the service worker for its [clientId](https://developer.mozilla.org/en-US/docs/Web/API/Client) on startup.
- Each tab spawns a dedicated logging worker with the query string `?tab=<client-id>`.
- The logging worker claims a lock matching the client ID in `location.searchParams` for its full lifetime.
- The logging worker claims a [web lock](https://developer.mozilla.org/en-US/docs/Web/API/LockManager/request) for the log file on startup using [ifAvailable](https://developer.mozilla.org/en-US/docs/Web/API/LockManager/request#ifavailable).
  - If it works (it's the first tab): open `logs/app.ndjson`. Receive 1+ message ports and drain logs into the file.
  - If it doesn't work:  
    - Re-request the lock without `ifAvailable` to hop onto the queue.
    - Query who holds the lock, then correlate it with the holder's other lock to find the parent's client ID.
    - Create a `MessageChannel` pair and send one end to the main thread with the parent's client ID.
    - The main thread sends it to the service worker, which relays it to the matching client ID (the other tab's window).
    - The receiving tab relays it to the logging worker as just another log producer.
    - The sending logging worker relays all inbound logs through the SW negotiated port.
    - The sending logging worker appends to the worker's lifetime lock. When it dies, buffer logs and repeat.
    - If the receiving logging worker dies *and* you claim the new lock, open OPFS, close the relay, write logs locally.
- The main process streams logs to the worker. The worker collects its own logs. The main process relays `MessagePort` instances from other workers to the dedicated worker.
- The service worker sends logs to any tab. It will eventually make it to the correct worker.

That's enough to maintain a single log file with durability across all tabs, workers, and _most_ of the service worker.

I didn't do it. It sounds absolutely hellish. I only wanted to know what it would cost.

> [!NOTE]
> The locking strategy would kill the site's [bfcache](https://developer.mozilla.org/en-US/docs/Glossary/bfcache) eligibility.

This PR description is better than therapy. I'm going to keep writing, because there's even more sources of surprise and pain.

## Transferable Streams: Surprise and Pain

My first attempt at OPFS implemented logging as a [WritableStream](https://developer.mozilla.org/en-US/docs/Web/API/WritableStream/WritableStream). It would be perfectly compatible with the async OPFS interface for simple use cases, and for complex ones, they're [realm transferable](https://developer.mozilla.org/en-US/docs/Web/API/Web_Workers_API/Transferable_objects). A dedicated worker could create the stream, send it to the main process, and you just plug it in.

The title gives it away. It was a terrible idea. Streams should not be transferable.

First, backpressure is signaled in two ways:
1. `writer.write(...)` won't resolve until it's ready for more data.
2. `writer.desiredSize` communicates available queue size.

The first works. The second doesn't. The queue size set by a worker will be silently erased on transfer. A workaround creates an intermediate `TransformStream` with a custom `CountQueuingStrategy`, but it won't match the receiving side.

Definitely surprising, but not a dealbreaker.

What's absolutely bonkers is when you transfer a writable stream, browsers transparently create a dedicated `MessageChannel`, transfer _that_ through the port, and create a writable receiver on the other end pretending to be the transfered stream.

This happens **for every transfer**.

That means streams aren't actually transferred. **They're relayed**. If any realm in the relay chain dies (say, a service worker) your stream is killed. Even when it works, you're paying silent overhead by doing multi-hop messaging because the stream has to hop through its entire transfer path. On every message.

If you'd filmed me when I learned that, it could've been used as one of those youtube reaction face posters. I still can't believe it.

Discussion and details here: https://github.com/whatwg/streams/issues/1063

---

So, after trying out OPFS and web streams as the interface for `@holz/json-backend`, it's safe to say this is a dead end for every possible interpretation.

I'm rolling back the interface change.