### PR TITLE
🤖 Format after version bump in release prep

### DIFF
--- a/bin/version-bump
+++ b/bin/version-bump
@@ -20,3 +20,10 @@ pnpm exec lerna version "$1" \
   --no-git-tag-version \
   --force-publish \
   --yes
+
+# lerna rewrites lerna.json without a trailing newline, which fails the
+# `fmt-check` step of `pnpm check` (treefmt/prettier). Re-run the same formatter
+# so the release-prep commit is already clean. Full-tree (not scoped to the
+# files lerna touched) so it stays correct if a future lerna rewrites something
+# else; prep starts from a clean tree, so nothing unrelated gets reformatted.
+treefmt


### PR DESCRIPTION
## TL;DR

`bin/version-bump` now runs `treefmt` after `lerna version`, so the release-prep commit is already formatted.

`lerna version` rewrites `lerna.json` without a trailing newline. Nothing re-formatted before the prep commit, so `fmt-check` (part of `pnpm check`) flagged it. This bit us during the **v0.9.0** release: the prep commit had to be amended by hand, and an un-amended commit would have failed CI's re-check in the `publish-stable` job.

## Change

- Append a full-tree `treefmt` at the end of `bin/version-bump`.
- Full-tree rather than scoped to `lerna.json`: it's the exact formatter `fmt-check` gates on, and it stays correct if a future `lerna` rewrites another file instead of silently missing it. Prep starts from a clean tree, so nothing unrelated is touched; treefmt's cache keeps it near-instant.

Validated end-to-end: ran the patched script against a throwaway bump → `treefmt --ci` exits clean.

## Pros

- Release prep no longer produces a commit that fails its own `fmt-check`.
- No more manual amend step during releases; removes a sharp edge that already caused a mid-release scramble.
- Future-proof against `lerna` reformatting other files.

## Cons

- Adds a `treefmt` dependency to the `version-bump` step (already present in the dev shell and CI, so no new tooling).
- If someone runs `version-bump` with a dirty working tree — against the runbook's clean-tree precondition — unrelated files would be formatted into the prep commit.

## Recommended followup

- Consider an alert on `publish-rc` failures. During this release the RC job had been silently red (`@holz/pattern-filter` stuck on an old `rc` version) until a stable release surfaced it.
